### PR TITLE
Custom template directory

### DIFF
--- a/src/SleepingOwl/Admin/Controllers/BaseController.php
+++ b/src/SleepingOwl/Admin/Controllers/BaseController.php
@@ -2,6 +2,7 @@
 
 use App;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Config;
 use SleepingOwl\Admin\Admin;
 use Illuminate\Foundation\Application;
 use View;
@@ -38,7 +39,7 @@ class BaseController extends Controller
 	 */
 	protected function makeView($name, $data = [])
 	{
-		$view = View::make('admin::' . $name, $data);
+		$view = View::make(Config::get('admin.bladePrefix') . $name, $data);
 		$this->addViewDefaults($view);
 		return $view;
 	}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -50,5 +50,10 @@ return [
 			'username' => 'required',
 			'password' => 'required',
 		]
-	]
+	],
+
+    /*
+	 * Blade template prefix, default admin::
+	 */
+    'bladePrefix'                => 'admin::',
 ];


### PR DESCRIPTION
I've added a config parameter that specify the blade prefix to be used when calling blade views.

That allows users to build their own blade backend template in their `resources/view/` folder (i'm currently working on an [AdminLTE](/almasaeed2010/AdminLTE) version), overriding the base template built with [SB-Admin 2](/IronSummitMedia/startbootstrap-sb-admin-2).

