### PR TITLE
Add showSeconds protected variable to timestamp class

### DIFF
--- a/src/SleepingOwl/Admin/Models/Form/FormItem/Timestamp.php
+++ b/src/SleepingOwl/Admin/Models/Form/FormItem/Timestamp.php
@@ -5,6 +5,10 @@ use SleepingOwl\DateFormatter\DateFormatter;
 class Timestamp extends BaseTime
 {
 	/**
+	 * @var bool
+	 */
+	protected $showSeconds = false;
+	/**
 	 * @return mixed
 	 */
 	public function render()


### PR DESCRIPTION
Hi,
There is an error when using the Timestamp form.
I looked at the Timestamp class and comparing it to the Time class, concluded that
protected $showSeconds = false;
was missing.
When I added this, the error disappeared. 
I did not check the BaseTime Class which both Classes are extended from.

Kind Regards
Nick