### PR TITLE
Allow chaining enum() method of SelectFormItem

### DIFF
--- a/src/SleepingOwl/Admin/Models/Form/FormItem/Select.php
+++ b/src/SleepingOwl/Admin/Models/Form/FormItem/Select.php
@@ -55,9 +55,16 @@ class Select extends BaseFormItem
 		return $select;
 	}
 
+	/**
+	 * @param array $values
+	 *
+	 * @return $this
+	 */
 	public function enum($values)
 	{
 		$this->list(array_combine($values, $values));
+
+		return $this;
 	}
 
 	function __call($name, $arguments)


### PR DESCRIPTION
Now we can chain enum() of Select form item.