### PR TITLE
Update intervention/image dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"php": ">=5.4.0",
 		"illuminate/support": "5.*",
-		"intervention/image": "2.1.3",
+		"intervention/image": "2.*",
 		"intervention/imagecache": "2.*",
 		"doctrine/dbal": "~2.3",
 		"sleeping-owl/with-join": "1.*",


### PR DESCRIPTION
Old version is buggy.

I was getting this https://github.com/Intervention/imagecache/issues/42.