### PR TITLE
Remove Bugfix within Multiselect / New Form Features

### DIFF
--- a/src/SleepingOwl/Admin/FormItems/NamedFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/NamedFormItem.php
@@ -8,6 +8,7 @@ abstract class NamedFormItem extends BaseFormItem
 	protected $name;
 	protected $label;
 	protected $defaultValue;
+	protected $readonly;
 
 	function __construct($name, $label = null)
 	{
@@ -38,9 +39,10 @@ abstract class NamedFormItem extends BaseFormItem
 	public function getParams()
 	{
 		return parent::getParams() + [
-			'name'  => $this->name(),
-			'label' => $this->label(),
-			'value' => $this->value(),
+			'name'      => $this->name(),
+			'label'     => $this->label(),
+			'readonly'  => $this->readonly(),
+			'value'     => $this->value()
 		];
 	}
 
@@ -51,6 +53,18 @@ abstract class NamedFormItem extends BaseFormItem
 			return $this->defaultValue;
 		}
 		$this->defaultValue = $defaultValue;
+		return $this;
+	}
+
+	public function readonly($readonly = null)
+	{
+		if (is_null($readonly))
+		{
+			return $this->readonly;
+		}
+
+		$this->readonly = $readonly;
+
 		return $this;
 	}
 

--- a/src/SleepingOwl/Admin/FormItems/Textarea.php
+++ b/src/SleepingOwl/Admin/FormItems/Textarea.php
@@ -2,7 +2,29 @@
 
 class Textarea extends NamedFormItem
 {
-
 	protected $view = 'textarea';
+	protected $rows = 10;
+
+
+	public function getParams()
+	{
+		return parent::getParams() + [
+			'name'      => $this->name(),
+			'label'     => $this->label(),
+			'readonly'  => $this->readonly(),
+			'value'     => $this->value(),
+			'rows'      => $this->rows()
+		];
+	}
+
+	public function rows($rows = null)
+	{
+		if (is_null($rows))
+		{
+			return $this->rows;
+		}
+		$this->rows = $rows;
+		return $this;
+	}
 
 }

--- a/src/views/default/formitem/date.blade.php
+++ b/src/views/default/formitem/date.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
 	<label for="{{ $name }}">{{ $label }}</label>
 	<div class="datepicker form-group input-group">
-		<input data-date-format="{{ $pickerFormat }}" data-date-pickdate="true" data-date-picktime="false" data-date-useseconds="{{ $seconds ? 'true' : 'false' }}" class="form-control" name="{{ $name }}" type="text" id="{{ $name }}" value="{{ $value }}">
+		<input data-date-format="{{ $pickerFormat }}" data-date-pickdate="true" data-date-picktime="false" data-date-useseconds="{{ $seconds ? 'true' : 'false' }}" class="form-control" name="{{ $name }}" type="text" id="{{ $name }}" value="{{ $value }}" @if(isset($readonly))readonly="{{ $readonly }}"@endif>
 		<span class="input-group-addon"><span class="fa fa-clock-o"></span></span>
 	</div>
 	@include(AdminTemplate::view('formitem.errors'))

--- a/src/views/default/formitem/multiselect.blade.php
+++ b/src/views/default/formitem/multiselect.blade.php
@@ -3,7 +3,7 @@
 	<div>
 		<select id="{{ $name }}" name="{{ $name }}[]" class="form-control multiselect" multiple="multiple">
 			@foreach ($options as $optionValue => $optionLabel)
-				<option value="{{ $optionValue }}" {!! in_array($optionValue, $value) ? 'selected="selected"' : '' !!}>{{ $optionLabel }}</option>
+				<option value="{{ $optionValue }}" {!! isset($value) && in_array($optionValue, $value) ? 'selected="selected"' : '' !!}>{{ $optionLabel }}</option>
 			@endforeach
 		</select>
 	</div>

--- a/src/views/default/formitem/password.blade.php
+++ b/src/views/default/formitem/password.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
 	<label for="{{ $name }}">{{ $label }}</label>
-	<input class="form-control" name="{{ $name }}" type="password" id="{{ $name }}" value="">
+	<input class="form-control" name="{{ $name }}" type="password" id="{{ $name }}" value="" @if(isset($readonly))readonly="{{ $readonly }}"@endif>
 	@include(AdminTemplate::view('formitem.errors'))
 </div>

--- a/src/views/default/formitem/text.blade.php
+++ b/src/views/default/formitem/text.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
 	<label for="{{ $name }}">{{ $label }}</label>
-	<input class="form-control" name="{{ $name }}" type="text" id="{{ $name }}" value="{{ $value }}">
+	<input class="form-control" name="{{ $name }}" type="text" id="{{ $name }}" value="{{ $value }}" @if(isset($readonly))readonly="{{ $readonly }}" @endif>
 	@include(AdminTemplate::view('formitem.errors'))
 </div>

--- a/src/views/default/formitem/textarea.blade.php
+++ b/src/views/default/formitem/textarea.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
 	<label for="{{ $name }}">{{ $label }}</label>
-	<textarea class="form-control" cols="50" rows="10" name="{{ $name }}">{!! $value !!}</textarea>
+	<textarea class="form-control" rows="{{ $rows }}" name="{{ $name }}" @if(isset($readonly))readonly="{{ $readonly }}"@endif>{!! $value !!}</textarea>
 	@include(AdminTemplate::view('formitem.errors'))
 </div>

--- a/src/views/default/formitem/time.blade.php
+++ b/src/views/default/formitem/time.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
 	<label for="{{ $name }}">{{ $label }}</label>
 	<div class="datepicker form-group input-group">
-		<input data-date-format="{{ $pickerFormat }}" data-date-pickdate="false" data-date-useseconds="{{ $seconds ? 'true' : 'false' }}" class="form-control" name="{{ $name }}" type="text" id="{{ $name }}" value="{{ $value }}">
+		<input data-date-format="{{ $pickerFormat }}" data-date-pickdate="false" data-date-useseconds="{{ $seconds ? 'true' : 'false' }}" class="form-control" name="{{ $name }}" type="text" id="{{ $name }}" value="{{ $value }}" @if(isset($readonly))readonly="{{ $readonly }}"@endif>
 		<span class="input-group-addon"><span class="fa fa-clock-o"></span></span>
 	</div>
 	@include(AdminTemplate::view('formitem.errors'))

--- a/src/views/default/formitem/timestamp.blade.php
+++ b/src/views/default/formitem/timestamp.blade.php
@@ -1,7 +1,7 @@
 <div class="form-group {{ $errors->has($name) ? 'has-error' : '' }}">
 	<label for="{{ $name }}">{{ $label }}</label>
 	<div class="datepicker form-group input-group">
-		<input data-date-format="{{ $pickerFormat }}" data-date-useseconds="{{ $seconds ? 'true' : 'false' }}" class="form-control" name="{{ $name }}" type="text" id="{{ $name }}" value="{{ $value }}">
+		<input data-date-format="{{ $pickerFormat }}" data-date-useseconds="{{ $seconds ? 'true' : 'false' }}" class="form-control" name="{{ $name }}" type="text" id="{{ $name }}" value="{{ $value }}" @if(isset($readonly))readonly="{{ $readonly }}"@endif>
 		<span class="input-group-addon"><span class="fa fa-clock-o"></span></span>
 	</div>
 	@include(AdminTemplate::view('formitem.errors'))


### PR DESCRIPTION
Hello @sleeping-owl,

following changed:

- MultiSelect throws error, when value is empty
- add support for readonly within input fields
- add support for "rows" attribute within textarea and remove unused cols attribute

Please give feedback when It's wrong! Thanks.