### PR TITLE
Fix primary key for multi-select

### DIFF
--- a/src/SleepingOwl/Admin/FormItems/MultiSelect.php
+++ b/src/SleepingOwl/Admin/FormItems/MultiSelect.php
@@ -10,7 +10,7 @@ class MultiSelect extends Select
 	public function value()
 	{
 		$value = parent::value();
-		if ($value instanceof Collection)
+		if ($value instanceof Collection  && $value->count() > 0)
 		{
 			$value = $value->lists($value->first()->getKeyName());
 		}

--- a/src/SleepingOwl/Admin/FormItems/MultiSelect.php
+++ b/src/SleepingOwl/Admin/FormItems/MultiSelect.php
@@ -12,7 +12,7 @@ class MultiSelect extends Select
 		$value = parent::value();
 		if ($value instanceof Collection)
 		{
-			$value = $value->lists('id');
+			$value = $value->lists($value->first()->getKeyName());
 		}
 		if ($value instanceof Collection)
 		{


### PR DESCRIPTION
The primary key of a model will not always be "id". This commit fixes this by using the key name from the model.