### PR TITLE
File and image fields bugfix

### DIFF
--- a/src/SleepingOwl/Html/FormBuilder.php
+++ b/src/SleepingOwl/Html/FormBuilder.php
@@ -300,7 +300,7 @@ class FormBuilder extends IlluminateFormBuilder
 			$innerContent .= '<div class="clearfix"></div>';
 			$content .= $this->html->tag('div', ['class' => 'img-container'], $innerContent);
 		}
-		$content .= $this->file($name, null, $options);
+		$content .= $this->file($name, $options);
 		return $this->makeGroup($name, $label, $content);
 	}
 
@@ -325,7 +325,7 @@ class FormBuilder extends IlluminateFormBuilder
 			$file = $this->html->tag('div', ['class' => 'thumbnail file-info'], $link);
 			$content .= $this->html->tag('div', [], $file);
 		}
-		$content .= $this->file($name, null, $options);
+		$content .= $this->file($name, $options);
 		return $this->makeGroup($name, $label, $content);
 	}
 

--- a/src/SleepingOwl/Models/Traits/ModelWithImageOrFileFieldsTrait.php
+++ b/src/SleepingOwl/Models/Traits/ModelWithImageOrFileFieldsTrait.php
@@ -243,7 +243,7 @@ trait ModelWithImageOrFileFieldsTrait
 				}
 			}
 		}
-		if (preg_match('/get(?<field>[a-zA-Z]+)Attribute/', $method, $attr))
+		if (preg_match('/get(?<field>[a-zA-Z0-9]+)Attribute/', $method, $attr))
 		{
 			$fields = [Str::lower($attr['field']), Str::camel($attr['field']), Str::snake($attr['field'])];
 			foreach ($fields as $field)


### PR DESCRIPTION
Fix: file fields were not working for field names containing numbers
Fix: file and image fields called \Illuminate\Html\FormBuilder::file() incorrently. They didn't pass the HTML attributes array correctly.