### PR TITLE
Fix for #166

### DIFF
--- a/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
@@ -37,6 +37,10 @@ abstract class BaseFormItem implements Renderable, FormItemInterface
 		{
 			return $this->validationRules;
 		}
+		if (is_string($validationRules))
++		{
++			$validationRules = explode('|', $validationRules);
++		}
 		$this->validationRules = $validationRules;
 		return $this;
 	}


### PR DESCRIPTION
```BaseFormItem::validationRules()``` can accept validation string (i.e. ```required|string|max:10```)