### PR TITLE
Update FormItem.php

### DIFF
--- a/src/SleepingOwl/Admin/Models/Form/FormItem.php
+++ b/src/SleepingOwl/Admin/Models/Form/FormItem.php
@@ -63,6 +63,7 @@ class FormItem
 			} else
 			{
 				$formItem = App::make($handler);
+				$formItem->__construct(Arr::get($params, 0, null), Arr::get($params, 1, ''));
 			}
 		} else
 		{


### PR DESCRIPTION
Описание бага:
В конструктор произвольного элемента формы не передаются параметры, в следствие чего произвольные элементы формы не получают никаких данных из модели

Пример:
...->form(function ()
{
    FormItem::approval('approved_at', 'Approved At')->default(time());
});

Попытка получить данные из класса данного элемента:
use SleepingOwl\Admin\Models\Form\FormItem\Timestamp;

class Approval extends Timestamp{
    public function render()
    {
        $instance = Admin::instance()->formBuilder->getModel();

        if((new \DateTime($instance->approved_at)) < (new \DateTime('2000-10-01')))
                 return 'closed';
        return parent::render(); // Вернется некорректный html-код. Атрибуты $this->name, $this->label равны NULL, т.к. в конструктор они не передались.
    }
}

Данный фикс исправляет эту проблему