### PR TITLE
FIXED: syntax error, unexpected '{'

### DIFF
--- a/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
@@ -38,9 +38,9 @@ abstract class BaseFormItem implements Renderable, FormItemInterface
 			return $this->validationRules;
 		}
 		if (is_string($validationRules))
-+		{
-+			$validationRules = explode('|', $validationRules);
-+		}
+		{
+			$validationRules = explode('|', $validationRules);
+		}
 		$this->validationRules = $validationRules;
 		return $this;
 	}


### PR DESCRIPTION
Symfony \ Component \ Debug \ Exception \ FatalErrorException (E_UNKNOWN)
syntax error, unexpected '{'

```
    if (is_string($validationRules))
```
-       {
-           $validationRules = explode('|', $validationRules);
-       }
