### PR TITLE
Fix MAC is invalid, issue #212

### DIFF
--- a/src/SleepingOwl/Admin/Helpers/StartSession.php
+++ b/src/SleepingOwl/Admin/Helpers/StartSession.php
@@ -41,7 +41,10 @@ class StartSession
 		$cookie = $request->cookies->get($session->getName());
 		if ( ! is_null($cookie))
 		{
-			$session->setId($this->encrypter->decrypt($cookie));
+			try{
+				$session->setId($this->encrypter->decrypt($cookie));
+			}
+			catch (\Exception $exc){}
 		}
 
 		return $session;


### PR DESCRIPTION
Hello, I fixed the problem discussed here:

https://github.com/sleeping-owl/admin/issues/212

Basically it's appear when the laravel_session cookie is already set, and something on server changes.
Ie: I experienced this problem passing from HTTP to HTTPS.
This is very annoying because the unique solution is to clear cookies.