### PR TITLE
Configurable Auth model

### DIFF
--- a/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/BaseFormItem.php
@@ -38,9 +38,9 @@ abstract class BaseFormItem implements Renderable, FormItemInterface
 			return $this->validationRules;
 		}
 		if (is_string($validationRules))
-+		{
-+			$validationRules = explode('|', $validationRules);
-+		}
+		{
+			$validationRules = explode('|', $validationRules);
+		}
 		$this->validationRules = $validationRules;
 		return $this;
 	}

--- a/src/SleepingOwl/Admin/Http/Controllers/AuthController.php
+++ b/src/SleepingOwl/Admin/Http/Controllers/AuthController.php
@@ -1,12 +1,12 @@
 <?php namespace SleepingOwl\Admin\Http\Controllers;
 
+use AdminAuth;
 use AdminTemplate;
 use App;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\MessageBag;
 use Input;
 use Redirect;
-use SleepingOwl\AdminAuth\Facades\AdminAuth;
 use Validator;
 
 class AuthController extends Controller


### PR DESCRIPTION
This simple change makes it possible to use your existing Auth model configured in `config/admin.php`, so e.g. I'm using :

```
/*
     * Authentication config
     */
    'auth'                    => [
        'model' => 'App\Models\User',
        'rules' => [
            'email' => 'required',
            'password' => 'required',
        ]
    ],
```

...which allows my normal users to log in to the admin area. The `Sleeping-Owl/AdminAuth` stuff is then unused.

Not tested extensively but doesn't seem to be causing any issues here.