### PR TITLE
Fix unique validation rule at record creation

### DIFF
--- a/src/SleepingOwl/Admin/FormItems/NamedFormItem.php
+++ b/src/SleepingOwl/Admin/FormItems/NamedFormItem.php
@@ -148,7 +148,7 @@ abstract class NamedFormItem extends BaseFormItem
 			{
 				$table = $this->instance()->getTable();
 				$item = 'unique:' . $table . ',' . $this->attribute();
-				if ($this->instance()->exists())
+				if ($this->instance()->exists)
 				{
 					$item .= ',' . $this->instance()->getKey();
 				}


### PR DESCRIPTION
The unique validation rule doesn't work when creating a new record.

We need to check that the record is new or is updated by checking the exists attribute and not the exists function that just check if there is any record in the relevant table.

